### PR TITLE
feat: progress card widget, with progress bar and child widget

### DIFF
--- a/lib/ui/views/all_reminders/all_reminders_screen.dart
+++ b/lib/ui/views/all_reminders/all_reminders_screen.dart
@@ -1,5 +1,7 @@
+import 'package:MedBuzz/core/constants/route_names.dart';
 import 'package:MedBuzz/ui/size_config/config.dart';
 import 'package:MedBuzz/ui/views/all_reminders/all_reminders_view_model.dart';
+import 'package:MedBuzz/ui/widget/appointment_card.dart';
 import 'package:MedBuzz/ui/widget/medication_card.dart';
 import 'package:MedBuzz/ui/widget/water_card.dart';
 import 'package:flutter/material.dart';
@@ -28,7 +30,11 @@ class AllRemindersScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        leading: BackButton(color: Theme.of(context).primaryColorDark),
+        leading: BackButton(
+            color: Theme.of(context).primaryColorDark,
+            onPressed: () {
+              Navigator.popAndPushNamed(context, RouteNames.homePage);
+            }),
         title: Text(
           'All reminders',
           style: TextStyle(color: Theme.of(context).primaryColorDark),
@@ -260,160 +266,7 @@ class AllRemindersScreen extends StatelessWidget {
                   ),
                   SizedBox(height: height * 0.02),
                   Text('08:00AM'),
-                  SizedBox(height: height * 0.02),
-                  Container(
-                    padding: EdgeInsets.symmetric(
-                        horizontal: Config.xMargin(context, 3),
-                        vertical: Config.yMargin(context, 1)),
-                    decoration: BoxDecoration(
-                      borderRadius:
-                          BorderRadius.circular(Config.xMargin(context, 6)),
-                      boxShadow: [
-                        BoxShadow(
-                          color: Colors.white,
-                          spreadRadius: 5,
-                        ),
-                      ],
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: <Widget>[
-                        GestureDetector(
-                          child: Icon(
-                            Icons.more_vert,
-                            size: Config.textSize(context, 5),
-                          ),
-                          onTap: () {},
-                        ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: [
-                            Column(
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                Text(
-                                  'July',
-                                  textAlign: TextAlign.center,
-                                  style: TextStyle(
-                                    fontSize: Config.textSize(context, 3),
-                                    color: Theme.of(context).hintColor,
-                                  ),
-                                ),
-                                Text(
-                                  '12',
-                                  style: TextStyle(
-                                    fontSize: Config.textSize(context, 7),
-                                    color: Theme.of(context).highlightColor,
-                                  ),
-                                ),
-                                Text(
-                                  'Thurs',
-                                  textAlign: TextAlign.center,
-                                  style: TextStyle(
-                                    fontSize: Config.textSize(context, 3),
-                                    color: Theme.of(context).hintColor,
-                                  ),
-                                ),
-                              ],
-                            ),
-                            SizedBox(
-                              width: Config.xMargin(context, 3),
-                            ),
-                            Container(
-                              color: Theme.of(context).primaryColorDark,
-                              height: height * 0.07,
-                              width: width * 0.001,
-                              child: VerticalDivider(),
-                            ),
-                            SizedBox(width: Config.xMargin(context, 5)),
-                            Expanded(
-                              child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Row(
-                                      children: [
-                                        Column(
-                                          crossAxisAlignment:
-                                              CrossAxisAlignment.start,
-                                          children: [
-                                            Text(
-                                              'Timing',
-                                              style: TextStyle(
-                                                fontSize: Config.textSize(
-                                                    context, 3.4),
-                                                color:
-                                                    Theme.of(context).hintColor,
-                                              ),
-                                            ),
-                                            SizedBox(
-                                              height:
-                                                  Config.yMargin(context, 1),
-                                            ),
-                                            Text(
-                                              '6.00 PM',
-                                              style: TextStyle(
-                                                  fontWeight: FontWeight.w600,
-                                                  fontSize: Config.textSize(
-                                                      context, 3.8)),
-                                            ),
-                                          ],
-                                        ),
-                                        SizedBox(
-                                            width: Config.xMargin(context, 9)),
-                                        Column(
-                                          crossAxisAlignment:
-                                              CrossAxisAlignment.start,
-                                          children: [
-                                            Text(
-                                              'Appointment for',
-                                              style: TextStyle(
-                                                fontSize: Config.textSize(
-                                                    context, 3.4),
-                                                color:
-                                                    Theme.of(context).hintColor,
-                                              ),
-                                            ),
-                                            SizedBox(
-                                              height:
-                                                  Config.yMargin(context, 1),
-                                            ),
-                                            Text(
-                                              'Dance Class',
-                                              style: TextStyle(
-                                                  fontWeight: FontWeight.w600,
-                                                  fontSize: Config.textSize(
-                                                      context, 3.8)),
-                                            ),
-                                          ],
-                                        ),
-                                      ],
-                                    ),
-                                    SizedBox(
-                                      height: height * 0.03,
-                                      width: double.infinity,
-                                      child: Divider(
-                                        color:
-                                            Theme.of(context).primaryColorDark,
-//indent: 50.0,
-                                        // endIndent: 10.0,
-                                      ),
-                                    ),
-                                    Container(
-                                      child: Text(
-                                        'Make sure to make lots of friends',
-                                        style: TextStyle(
-                                            fontSize:
-                                                Config.textSize(context, 3.8)),
-                                      ),
-                                    ),
-                                  ]),
-                            ),
-                          ],
-                        ),
-                      ],
-                    ),
-                  ),
+                  AppointmentCard(width: width, height: height),
                 ],
               ),
             ),

--- a/lib/ui/views/home_screen/home_page.dart
+++ b/lib/ui/views/home_screen/home_page.dart
@@ -1,9 +1,13 @@
 import 'package:MedBuzz/core/constants/route_names.dart';
+import 'package:MedBuzz/core/database/waterReminderData.dart';
 import 'package:MedBuzz/ui/views/add_medication/add_medication_screen.dart';
 import 'package:MedBuzz/ui/views/all_reminders/all_reminders_screen.dart';
 import 'package:MedBuzz/ui/views/fitness_reminders/add_fitness_screen.dart';
 import 'package:MedBuzz/ui/views/home_screen/home_screen_model.dart';
 import 'package:MedBuzz/ui/views/profile_page.dart';
+import 'package:MedBuzz/ui/widget/appointment_card.dart';
+import 'package:MedBuzz/ui/widget/medication_card.dart';
+import 'package:MedBuzz/ui/widget/progress_card.dart';
 import 'package:flutter/material.dart';
 import 'package:bubbled_navigation_bar/bubbled_navigation_bar.dart';
 import 'package:flutter/cupertino.dart';
@@ -54,6 +58,12 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     var model = Provider.of<HomeScreenModel>(context);
+    var waterReminderDB = Provider.of<WaterReminderData>(context);
+    waterReminderDB.getWaterReminders();
+
+    double height = MediaQuery.of(context).size.height;
+    double width = MediaQuery.of(context).size.width;
+
     return Scaffold(
         backgroundColor: Colors.grey.shade100,
         body: NotificationListener<ScrollNotification>(
@@ -66,12 +76,13 @@ class _HomePageState extends State<HomePage> {
               children: [
                 SafeArea(
                   child: ListView(physics: BouncingScrollPhysics(), children: [
-                    Column(
-                      children: [
-                        Padding(
-                          padding: EdgeInsets.symmetric(
-                              horizontal: 30.0, vertical: 40.0),
-                          child: Row(
+                    Padding(
+                      padding: EdgeInsets.symmetric(
+                        horizontal: Config.xMargin(context, 6),
+                      ),
+                      child: Column(
+                        children: [
+                          Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               Column(
@@ -83,7 +94,6 @@ class _HomePageState extends State<HomePage> {
                                     style: TextStyle(
                                       fontSize: 18,
                                       color: color = Color(0xff333333),
-                                      fontFamily: 'Segoe',
                                     ),
                                   ),
                                   SizedBox(
@@ -95,7 +105,6 @@ class _HomePageState extends State<HomePage> {
                                       fontSize: 24,
                                       fontWeight: FontWeight.w600,
                                       color: color = Color(0xff333333),
-                                      fontFamily: 'Segoe',
                                     ),
                                   ),
                                 ],
@@ -109,33 +118,11 @@ class _HomePageState extends State<HomePage> {
                               ),
                             ],
                           ),
-                        ),
-                        Container(
-                          margin: EdgeInsets.only(
-                              bottom: 10.0, left: 24.0, right: 24.0),
-                          height: Config.yMargin(context, 20),
-                          width: Config.xMargin(context, 100),
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(20.0),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.white,
-                                spreadRadius: 5,
-                                //blurRadius: 2,
-                                //offset: Offset(0, 3), // changes position of shadow
-                              ),
-                            ],
-                          ),
-                          child: Column(
-                            //crossAxisAlignment: CrossAxisAlignment.center,
-                            mainAxisAlignment: MainAxisAlignment.center,
-                            children: [
-                              Padding(
-                                padding: EdgeInsets.only(
-                                    left: 25.0,
-                                    right: 25.0,
-                                    top: 10.0,
-                                    bottom: 17.0),
+                          SizedBox(height: height * 0.05),
+                          GestureDetector(
+                            onTap: () => Navigator.pushNamed(
+                                context, RouteNames.waterScheduleView),
+                            child: ProgressCard(
                                 child: Row(
                                   children: [
                                     Image.asset('images/waterdrop.png'),
@@ -148,13 +135,14 @@ class _HomePageState extends State<HomePage> {
                                           CrossAxisAlignment.start,
                                       children: [
                                         Text(
-                                          'Water tracker',
+                                          'Water Tracker',
                                           style: TextStyle(
-                                            fontWeight: FontWeight.w600,
-                                            fontSize: 14.0,
-                                            color: color = Color(0xff777777),
-                                            fontFamily: 'Segoe',
-                                          ),
+                                              fontWeight: FontWeight.w600,
+                                              fontSize:
+                                                  Config.textSize(context, 3.5),
+                                              color: Theme.of(context)
+                                                  .primaryColorDark
+                                                  .withOpacity(0.5)),
                                         ),
                                         SizedBox(
                                           height: Config.yMargin(context, 1.5),
@@ -165,19 +153,19 @@ class _HomePageState extends State<HomePage> {
                                               '250ml',
                                               style: TextStyle(
                                                 fontWeight: FontWeight.w600,
-                                                fontSize: 18.0,
-                                                color: color =
-                                                    Color(0xff333333),
-                                                fontFamily: 'Segoe',
+                                                fontSize:
+                                                    Config.textSize(context, 4),
+                                                color: Theme.of(context)
+                                                    .primaryColorDark,
                                               ),
                                             ),
                                             Text(
                                               ' of 3500ml',
                                               style: TextStyle(
-                                                fontSize: 14.0,
-                                                color: color =
-                                                    Color(0xff333333),
-                                                fontFamily: 'Segoe',
+                                                fontSize: Config.textSize(
+                                                    context, 3.7),
+                                                color: Theme.of(context)
+                                                    .primaryColorDark,
                                               ),
                                             ),
                                           ],
@@ -186,62 +174,23 @@ class _HomePageState extends State<HomePage> {
                                     ),
                                   ],
                                 ),
-                              ),
-                              Padding(
-                                padding: const EdgeInsets.only(
-                                    top: 3.0,
-                                    left: 15.0,
-                                    right: 24.0,
-                                    bottom: 17.0),
-                                child: Stack(
-                                  children: [
-                                    Container(
-                                      height: Config.yMargin(context, 2),
-                                      decoration: BoxDecoration(
-                                          color: color = Color(0xffEEEEEE),
-                                          borderRadius:
-                                              BorderRadius.circular(10.0)),
-                                    ),
-                                    Container(
-                                      height: Config.yMargin(context, 2),
-                                      width: Config.xMargin(context, 25),
-                                      decoration: BoxDecoration(
-                                          color: Theme.of(context).primaryColor,
-                                          borderRadius:
-                                              BorderRadius.circular(10.0)),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ],
+                                progressBarColor:
+                                    Theme.of(context).primaryColor,
+                                title: 'Water Tracker',
+                                progress: 250,
+                                total: 3500,
+                                width: width,
+                                height: height * 0.02),
                           ),
-                        ),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
-                          children: [
-                            Expanded(
-                              child: Container(
-                                margin: EdgeInsets.only(
-                                    left: 24.0,
-                                    right: 27.0,
-                                    bottom: 24.0,
-                                    top: 24.0),
-                                height: Config.yMargin(context, 20),
-                                width: Config.xMargin(context, 100),
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(20.0),
-                                  boxShadow: [
-                                    BoxShadow(
-                                      color: Colors.white,
-                                      spreadRadius: 5,
-                                      //blurRadius: 2,
-                                      //offset: Offset(0, 3), // changes position of shadow
-                                    ),
-                                  ],
-                                ),
-                                child: Padding(
-                                  padding: const EdgeInsets.only(
-                                      left: 16.0, right: 15.0),
+                          SizedBox(height: height * 0.05),
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            mainAxisSize: MainAxisSize.max,
+                            children: [
+                              GestureDetector(
+                                onTap: () => Navigator.pushNamed(
+                                    context, RouteNames.singleDietScreen),
+                                child: ProgressCard(
                                   child: Column(
                                     mainAxisAlignment: MainAxisAlignment.center,
                                     crossAxisAlignment:
@@ -250,11 +199,12 @@ class _HomePageState extends State<HomePage> {
                                       Text(
                                         'Meal',
                                         style: TextStyle(
-                                          fontWeight: FontWeight.w600,
-                                          fontSize: 14.0,
-                                          color: color = Color(0xff777777),
-                                          fontFamily: 'Segoe',
-                                        ),
+                                            fontWeight: FontWeight.w600,
+                                            fontSize:
+                                                Config.textSize(context, 3.3),
+                                            color: Theme.of(context)
+                                                .primaryColorDark
+                                                .withOpacity(0.5)),
                                       ),
                                       SizedBox(
                                         height: Config.yMargin(context, 1.5),
@@ -266,7 +216,6 @@ class _HomePageState extends State<HomePage> {
                                           fontSize: 18.0,
                                           color: Theme.of(context)
                                               .primaryColorDark,
-                                          fontFamily: 'Segoe',
                                         ),
                                       ),
                                       SizedBox(
@@ -275,159 +224,77 @@ class _HomePageState extends State<HomePage> {
                                       Text(
                                         'calories today',
                                         style: TextStyle(
-                                          fontSize: 12.0,
-                                          color: color = Color(0xff777777),
-                                          fontFamily: 'Segoe',
-                                        ),
-                                      ),
-                                      SizedBox(
-                                        height: Config.yMargin(context, 2),
-                                      ),
-                                      Stack(
-                                        children: [
-                                          Container(
-                                            padding: EdgeInsets.only(
-                                                left: 16.0,
-                                                right: 16.0,
-                                                top: 16.0,
-                                                bottom: 16.0),
-                                            height: Config.yMargin(context, 1),
-                                            decoration: BoxDecoration(
-                                                color: color =
-                                                    Color(0xffEEEEEE),
-                                                borderRadius:
-                                                    BorderRadius.circular(
-                                                        20.0)),
-                                          ),
-                                          Container(
-                                            padding: EdgeInsets.only(
-                                                left: 16.0,
-                                                top: 16.0,
-                                                bottom: 16.0),
-                                            height: Config.yMargin(context, 1),
-                                            width: Config.xMargin(context, 14),
-                                            decoration: BoxDecoration(
-                                                color: Theme.of(context)
-                                                    .buttonColor,
-                                                borderRadius:
-                                                    BorderRadius.circular(
-                                                        20.0)),
-                                          ),
-                                        ],
+                                            fontSize: 12.0,
+                                            color: color = Theme.of(context)
+                                                .primaryColorDark
+                                                .withOpacity(0.5)),
                                       ),
                                     ],
                                   ),
+                                  progress: 2500,
+                                  total: 3500,
+                                  width: width * 0.4,
+                                  height: height * 0.01,
+                                  progressBarColor:
+                                      Theme.of(context).buttonColor,
                                 ),
                               ),
-                            ),
-                            Expanded(
-                              child: Container(
-                                margin: EdgeInsets.only(
-                                    left: 20.0,
-                                    right: 24.0,
-                                    bottom: 24.0,
-                                    top: 24.0),
-                                height: Config.yMargin(context, 20),
-                                width: Config.xMargin(context, 100),
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(20.0),
-                                  boxShadow: [
-                                    BoxShadow(
-                                      color: Colors.white,
-                                      spreadRadius: 5,
-                                      //blurRadius: 2,
-                                      //offset: Offset(0, 3), // changes position of shadow
-                                    ),
-                                  ],
-                                ),
-                                child: Padding(
-                                  padding:
-                                      EdgeInsets.only(left: 16.0, right: 15.0),
+                              GestureDetector(
+                                onTap: () => Navigator.pushNamed(
+                                    context, RouteNames.fitnessSchedulesScreen),
+                                child: ProgressCard(
                                   child: Column(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        'Steps',
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.w600,
-                                          fontSize: 14.0,
-                                          color: color = Color(0xff777777),
-                                          fontFamily: 'Segoe',
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.center,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
+                                      children: [
+                                        Text(
+                                          'Steps',
+                                          style: TextStyle(
+                                              fontWeight: FontWeight.w600,
+                                              fontSize:
+                                                  Config.textSize(context, 3.3),
+                                              color: color = Theme.of(context)
+                                                  .primaryColorDark
+                                                  .withOpacity(0.5)),
                                         ),
-                                      ),
-                                      SizedBox(
-                                        height: Config.yMargin(context, 1.5),
-                                      ),
-                                      Text(
-                                        '7500',
-                                        style: TextStyle(
-                                          fontWeight: FontWeight.w600,
-                                          fontSize: 18.0,
-                                          color: Theme.of(context)
-                                              .primaryColorDark,
-                                          fontFamily: 'Segoe',
+                                        SizedBox(
+                                          height: Config.yMargin(context, 1.5),
                                         ),
-                                      ),
-                                      SizedBox(
-                                        height: Config.yMargin(context, 1),
-                                      ),
-                                      Text(
-                                        'steps today',
-                                        style: TextStyle(
-                                          fontSize: 12.0,
-                                          color: color = Color(0xff777777),
-                                          fontFamily: 'Segoe',
-                                        ),
-                                      ),
-                                      SizedBox(
-                                        height: Config.yMargin(context, 2),
-                                      ),
-                                      Stack(
-                                        children: [
-                                          Container(
-                                            padding: EdgeInsets.only(
-                                                left: 16.0,
-                                                right: 16.0,
-                                                top: 16.0,
-                                                bottom: 16.0),
-                                            height: Config.yMargin(context, 1),
-                                            decoration: BoxDecoration(
-                                                color: color =
-                                                    Color(0xffEEEEEE),
-                                                borderRadius:
-                                                    BorderRadius.circular(
-                                                        20.0)),
+                                        Text(
+                                          '7500',
+                                          style: TextStyle(
+                                            fontWeight: FontWeight.w600,
+                                            fontSize: 18.0,
+                                            color: Theme.of(context)
+                                                .primaryColorDark,
                                           ),
-                                          Container(
-                                            padding: EdgeInsets.only(
-                                                left: 16.0,
-                                                top: 16.0,
-                                                bottom: 16.0),
-                                            height: Config.yMargin(context, 1),
-                                            width: Config.xMargin(context, 14),
-                                            decoration: BoxDecoration(
-                                                color: color =
-                                                    Color(0xff76DBC9),
-                                                borderRadius:
-                                                    BorderRadius.circular(
-                                                        20.0)),
-                                          ),
-                                        ],
-                                      ),
-                                    ],
-                                  ),
+                                        ),
+                                        SizedBox(
+                                          height: Config.yMargin(context, 1),
+                                        ),
+                                        Text(
+                                          'steps today',
+                                          style: TextStyle(
+                                              fontSize: 12.0,
+                                              color: color = Theme.of(context)
+                                                  .primaryColorDark
+                                                  .withOpacity(0.5)),
+                                        ),
+                                      ]),
+                                  progress: 1500,
+                                  total: 3500,
+                                  width: width * 0.4,
+                                  height: height * 0.01,
+                                  progressBarColor:
+                                      Theme.of(context).highlightColor,
                                 ),
                               ),
-                            ),
-                          ],
-                        ),
-                        Padding(
-                          padding: EdgeInsets.only(
-                            left: 20.0,
+                            ],
                           ),
-                          child: Row(
+                          SizedBox(height: height * 0.05),
+                          Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               Text(
@@ -435,143 +302,27 @@ class _HomePageState extends State<HomePage> {
                                 style: TextStyle(
                                   fontSize: 18.0,
                                   fontWeight: FontWeight.w600,
-                                  fontFamily: 'Segoe',
                                 ),
                               ),
                               FlatButton(
-                                onPressed: () {},
+                                onPressed: () {
+                                  Navigator.popAndPushNamed(
+                                      context, RouteNames.medicationScreen);
+                                },
                                 child: Text(
                                   'See all',
                                   style: TextStyle(
-                                    fontSize: 14.0,
+                                    fontSize: Config.textSize(context, 3.3),
                                     fontWeight: FontWeight.w600,
-                                    color: color = Color(0xff2D7DD2),
-                                    fontFamily: 'Segoe',
+                                    color: Theme.of(context).primaryColor,
                                   ),
                                 ),
                               ),
                             ],
                           ),
-                        ),
-                        Container(
-                          margin: EdgeInsets.all(24.0),
-                          padding: EdgeInsets.only(left: 10.0, right: 24.0),
-                          height: Config.yMargin(context, 25),
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(20.0),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.white,
-                                spreadRadius: 5,
-                                //blurRadius: 2,
-                                //offset: Offset(0, 3), // changes position of shadow
-                              ),
-                            ],
-                          ),
-                          child: Column(
-                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                            children: [
-                              Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceEvenly,
-                                children: [
-                                  Padding(
-                                    padding: const EdgeInsets.only(right: 10.0),
-                                    child: Image.asset(
-                                      'images/injection.png',
-                                    ),
-                                  ),
-                                  Column(
-                                    children: [
-                                      Text(
-                                        'Promethazine',
-                                        style: TextStyle(
-                                          fontSize: 16,
-                                          fontWeight: FontWeight.bold,
-                                          fontFamily: 'Segoe',
-                                        ),
-                                      ),
-                                      SizedBox(
-                                        height: Config.yMargin(context, 2),
-                                      ),
-                                      Text(
-                                        '1 shots once daily',
-                                        style: TextStyle(
-                                          fontSize: 16,
-                                          fontFamily: 'Segoe',
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                  Padding(
-                                    padding: const EdgeInsets.only(
-                                        bottom: 30.0, left: 15.0),
-                                    child: Column(
-                                      children: [
-                                        Text(
-                                          '12pm',
-                                          style: TextStyle(
-                                            fontSize: 16,
-                                            fontFamily: 'Segoe',
-                                          ),
-                                        )
-                                      ],
-                                    ),
-                                  ),
-                                ],
-                              ),
-                              SizedBox(
-                                height: Config.yMargin(context, 1),
-                                width: Config.xMargin(context, 75),
-                                child: Divider(
-                                  color: Theme.of(context).primaryColorDark,
-                                  indent: 5.0,
-                                ),
-                              ),
-                              Row(
-                                mainAxisAlignment:
-                                    MainAxisAlignment.spaceEvenly,
-                                children: [
-                                  FlatButton(
-                                      onPressed: () {},
-                                      child: Text(
-                                        'View',
-                                        style: TextStyle(
-                                          fontSize: 16,
-                                          fontWeight: FontWeight.bold,
-                                          fontFamily: 'Segoe',
-                                        ),
-                                      )),
-                                  FlatButton.icon(
-                                      onPressed: () {},
-                                      icon: Icon(Icons.close),
-                                      label: Text(
-                                        'Skip',
-                                        style: TextStyle(
-                                          fontSize: 16,
-                                          fontWeight: FontWeight.bold,
-                                          fontFamily: 'Segoe',
-                                        ),
-                                      )),
-                                  FlatButton.icon(
-                                      onPressed: () {},
-                                      icon: Icon(Icons.check),
-                                      label: Text(
-                                        'Done',
-                                        style: TextStyle(
-                                          fontSize: 16,
-                                          fontWeight: FontWeight.bold,
-                                          fontFamily: 'Segoe',
-                                        ),
-                                      )),
-                                ],
-                              ),
-                            ],
-                          ),
-                        ),
-                        Padding(
-                          padding: EdgeInsets.only(left: 20.0),
-                          child: Row(
+                          MedicationCard(height: height, width: width),
+                          SizedBox(height: height * 0.05),
+                          Row(
                             mainAxisAlignment: MainAxisAlignment.spaceBetween,
                             children: [
                               Text(
@@ -579,195 +330,27 @@ class _HomePageState extends State<HomePage> {
                                 style: TextStyle(
                                   fontSize: 18.0,
                                   fontWeight: FontWeight.w600,
-                                  fontFamily: 'Segoe',
                                 ),
                               ),
                               FlatButton(
-                                onPressed: () {},
+                                onPressed: () {
+                                  Navigator.popAndPushNamed(context,
+                                      RouteNames.viewAppointmentScreen);
+                                },
                                 child: Text(
                                   'See all',
                                   style: TextStyle(
-                                    fontSize: 14.0,
+                                    fontSize: Config.textSize(context, 3.3),
                                     fontWeight: FontWeight.w600,
-                                    color: color = Color(0xff2D7DD2),
-                                    fontFamily: 'Segoe',
+                                    color: Theme.of(context).primaryColor,
                                   ),
                                 ),
                               ),
                             ],
                           ),
-                        ),
-                        Container(
-                          margin: EdgeInsets.all(24.0),
-                          padding: EdgeInsets.all(8.0),
-                          height: Config.yMargin(context, 20),
-                          width: Config.xMargin(context, 100),
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(20.0),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.white,
-                                spreadRadius: 5,
-                                //blurRadius: 2,
-                                //offset: Offset(0, 3), // changes position of shadow
-                              ),
-                            ],
-                          ),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Padding(
-                                padding: EdgeInsets.all(4.0),
-                                child: Column(
-                                  mainAxisAlignment: MainAxisAlignment.center,
-                                  children: [
-                                    Text(
-                                      'July',
-                                      textAlign: TextAlign.center,
-                                      style: TextStyle(
-                                        fontSize: 9.0,
-                                        color: color = Color(0xff777777),
-                                        fontFamily: 'Segoe',
-                                      ),
-                                    ),
-                                    Text(
-                                      '12',
-                                      style: TextStyle(
-                                        fontSize: 28.0,
-                                        color: color = Color(0xff2DBFC3),
-                                        fontFamily: 'Segoe',
-                                      ),
-                                    ),
-                                    Text(
-                                      'Thurs',
-                                      textAlign: TextAlign.center,
-                                      style: TextStyle(
-                                        fontSize: 9.0,
-                                        color: color = Color(0xff777777),
-                                        fontFamily: 'Segoe',
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                              SizedBox(
-                                width: Config.xMargin(context, 3),
-                              ),
-                              Container(
-                                color: Colors.black45,
-                                height: Config.yMargin(context, 8),
-                                width: Config.xMargin(context, 0.1),
-                                child: VerticalDivider(
-                                  indent: 25.0,
-                                  endIndent: 25.0,
-                                ),
-                              ),
-                              SizedBox(
-                                width: Config.xMargin(context, 5),
-                              ),
-                              Expanded(
-                                child: Column(
-                                    mainAxisAlignment: MainAxisAlignment.center,
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Row(
-                                        children: [
-                                          Column(
-                                            crossAxisAlignment:
-                                                CrossAxisAlignment.start,
-                                            children: [
-                                              Text(
-                                                'Timing',
-                                                style: TextStyle(
-                                                  fontSize: 12.0,
-                                                  color: color =
-                                                      Color(0xff777777),
-                                                  fontFamily: 'Segoe',
-                                                ),
-                                              ),
-                                              SizedBox(
-                                                height:
-                                                    Config.yMargin(context, 1),
-                                              ),
-                                              Text(
-                                                '6.00 PM',
-                                                style: TextStyle(
-                                                  fontWeight: FontWeight.w600,
-                                                  fontSize: 14.0,
-                                                  fontFamily: 'Segoe',
-                                                ),
-                                              ),
-                                            ],
-                                          ),
-                                          SizedBox(
-                                            width: Config.xMargin(context, 9),
-                                          ),
-                                          Column(
-                                            crossAxisAlignment:
-                                                CrossAxisAlignment.start,
-                                            children: [
-                                              Text(
-                                                'Appointment for',
-                                                style: TextStyle(
-                                                  fontSize: 12.0,
-                                                  color: color =
-                                                      Color(0xff777777),
-                                                  fontFamily: 'Segoe',
-                                                ),
-                                              ),
-                                              SizedBox(
-                                                height:
-                                                    Config.yMargin(context, 1),
-                                              ),
-                                              Text(
-                                                'Dance Class',
-                                                style: TextStyle(
-                                                  fontWeight: FontWeight.w600,
-                                                  fontSize: 14.0,
-                                                  fontFamily: 'Segoe',
-                                                ),
-                                              ),
-                                            ],
-                                          ),
-                                        ],
-                                      ),
-                                      SizedBox(
-                                        height: Config.yMargin(context, 3),
-                                        width: Config.xMargin(context, 63),
-                                        child: Divider(
-                                          color: Theme.of(context)
-                                              .primaryColorDark,
-                                          //indent: 50.0,
-                                          endIndent: 10.0,
-                                        ),
-                                      ),
-                                      Container(
-                                        width: Config.xMargin(context, 50),
-                                        height: Config.yMargin(context, 6),
-                                        child: Text(
-                                          'Make sure to make lots of friends',
-                                          style: TextStyle(
-                                            fontSize: 14.0,
-                                            fontFamily: 'Segoe',
-                                          ),
-                                        ),
-                                      ),
-                                    ]),
-                              ),
-                              Container(
-                                child: IconButton(
-                                  icon: Icon(Icons.more_vert),
-                                  onPressed: () {},
-                                  padding: EdgeInsets.only(
-                                      bottom: 100.0, left: 28.0),
-                                  color: Colors.grey,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
+                          AppointmentCard(height: height, width: width),
+                        ],
+                      ),
                     ),
                   ]),
                 ),

--- a/lib/ui/views/water_reminders/water_reminders_view.dart
+++ b/lib/ui/views/water_reminders/water_reminders_view.dart
@@ -1,3 +1,4 @@
+import 'package:MedBuzz/core/constants/route_names.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -99,9 +100,17 @@ class _WaterScheduleViewState extends State<WaterScheduleView> {
     formattedTime = DateFormat.jm().format(time);
     double height = MediaQuery.of(context).size.height;
     double width = MediaQuery.of(context).size.width;
-    return Container(
-      margin: EdgeInsets.only(top: 60),
-      child: SingleChildScrollView(
+    return Scaffold(
+      // margin: EdgeInsets.only(top: 60),
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        leading: BackButton(
+            color: Theme.of(context).primaryColorDark,
+            onPressed: () =>
+                {Navigator.of(context).popAndPushNamed(RouteNames.homePage)}),
+        elevation: 0,
+      ),
+      body: SingleChildScrollView(
         //container wrapping all the widgets
         child: Container(
           margin: EdgeInsets.only(

--- a/lib/ui/widget/appointment_card.dart
+++ b/lib/ui/widget/appointment_card.dart
@@ -1,0 +1,160 @@
+import 'package:MedBuzz/ui/size_config/config.dart';
+import 'package:flutter/material.dart';
+
+class AppointmentCard extends StatelessWidget {
+  final double height;
+  final double width;
+  const AppointmentCard({Key key, this.height, this.width}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Column(
+        children: <Widget>[
+          SizedBox(height: height * 0.02),
+          Container(
+            padding: EdgeInsets.symmetric(
+                horizontal: Config.xMargin(context, 3),
+                vertical: Config.yMargin(context, 1)),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(Config.xMargin(context, 6)),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.white,
+                  spreadRadius: 5,
+                ),
+              ],
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: <Widget>[
+                GestureDetector(
+                  child: Icon(
+                    Icons.more_vert,
+                    size: Config.textSize(context, 5),
+                  ),
+                  onTap: () {},
+                ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          'July',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: Config.textSize(context, 3),
+                            color: Theme.of(context).hintColor,
+                          ),
+                        ),
+                        Text(
+                          '12',
+                          style: TextStyle(
+                            fontSize: Config.textSize(context, 7),
+                            color: Theme.of(context).highlightColor,
+                          ),
+                        ),
+                        Text(
+                          'Thurs',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(
+                            fontSize: Config.textSize(context, 3),
+                            color: Theme.of(context).hintColor,
+                          ),
+                        ),
+                      ],
+                    ),
+                    SizedBox(
+                      width: Config.xMargin(context, 3),
+                    ),
+                    Container(
+                      color: Theme.of(context).primaryColorDark,
+                      height: height * 0.07,
+                      width: width * 0.001,
+                      child: VerticalDivider(),
+                    ),
+                    SizedBox(width: Config.xMargin(context, 5)),
+                    Expanded(
+                      child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Row(
+                              children: [
+                                Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      'Timing',
+                                      style: TextStyle(
+                                        fontSize: Config.textSize(context, 3.4),
+                                        color: Theme.of(context).hintColor,
+                                      ),
+                                    ),
+                                    SizedBox(
+                                      height: Config.yMargin(context, 1),
+                                    ),
+                                    Text(
+                                      '6.00 PM',
+                                      style: TextStyle(
+                                          fontWeight: FontWeight.w600,
+                                          fontSize:
+                                              Config.textSize(context, 3.8)),
+                                    ),
+                                  ],
+                                ),
+                                SizedBox(width: Config.xMargin(context, 9)),
+                                Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      'Appointment for',
+                                      style: TextStyle(
+                                        fontSize: Config.textSize(context, 3.4),
+                                        color: Theme.of(context).hintColor,
+                                      ),
+                                    ),
+                                    SizedBox(
+                                      height: Config.yMargin(context, 1),
+                                    ),
+                                    Text(
+                                      'Dance Class',
+                                      style: TextStyle(
+                                          fontWeight: FontWeight.w600,
+                                          fontSize:
+                                              Config.textSize(context, 3.8)),
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                            SizedBox(
+                              height: height * 0.03,
+                              width: double.infinity,
+                              child: Divider(
+                                color: Theme.of(context).primaryColorDark,
+//indent: 50.0,
+                                // endIndent: 10.0,
+                              ),
+                            ),
+                            Container(
+                              child: Text(
+                                'Make sure to make lots of friends',
+                                style: TextStyle(
+                                    fontSize: Config.textSize(context, 3.8)),
+                              ),
+                            ),
+                          ]),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/widget/medication_card.dart
+++ b/lib/ui/widget/medication_card.dart
@@ -14,146 +14,157 @@ class _MedicationCardState extends State<MedicationCard> {
   bool isSelected = false;
   @override
   Widget build(BuildContext context) {
-    return Container(
-      width: double.infinity,
-      child: GestureDetector(
-        //Navigate to screen with single reminder i.e the on user clicked on
-        onTap: () {
-          setState(() => isSelected = !isSelected);
-        },
-        child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                "8:00 AM",
-              ),
-              SizedBox(height: widget.height * 0.02),
-              Container(
-                  width: widget.width,
-                  padding: EdgeInsets.symmetric(
-                      horizontal: Config.xMargin(context, 3),
-                      vertical: Config.yMargin(context, 1)),
-                  decoration: BoxDecoration(
-                    color: isSelected == true
-                        ? Theme.of(context).primaryColor
-                        : Theme.of(context).primaryColorLight,
-                    borderRadius:
-                        BorderRadius.circular(Config.xMargin(context, 5)),
-                    boxShadow: [
-                      BoxShadow(
-                        color: isSelected == true
-                            ? isSelected ? Theme.of(context).primaryColorLight: Theme.of(context).primaryColorDark
-                            : Colors.grey[50],
-                        spreadRadius: 5,
-//blurRadius: 2,
-//offset: Offset(0, 3), // changes position of shadow
-                      ),
-                    ],
-                  ),
-                  child: Column(
-                    children: <Widget>[
-                      Row(
-                        children: <Widget>[
-                          Image.asset(
-                             "images/injection.png",
+    return GestureDetector(
+      //Navigate to screen with single reminder i.e the on user clicked on
+      onTap: () {
+        setState(() => isSelected = !isSelected);
+      },
+
+      child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.max,
+          children: [
+            Text(
+              "8:00 AM",
+            ),
+            SizedBox(height: widget.height * 0.02),
+            Container(
+                width: widget.width,
+                padding: EdgeInsets.symmetric(
+                    horizontal: Config.xMargin(context, 3),
+                    vertical: Config.yMargin(context, 1)),
+                decoration: BoxDecoration(
+                  color: isSelected
+                      ? Theme.of(context).primaryColor
+                      : Theme.of(context).primaryColorLight,
+                  borderRadius:
+                      BorderRadius.circular(Config.xMargin(context, 5)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Theme.of(context).primaryColorLight,
+                      spreadRadius: Config.xMargin(context, 2),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  children: <Widget>[
+                    Row(
+                      children: <Widget>[
+                        Image.asset(
+                          "images/injection.png",
 //                            color: Theme.of(context).primaryColorLight,
-                            width: widget.width * 0.2,
-                            height: widget.height * 0.1,
-                          ),
-                          Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: <Widget>[
-                              Text(
-                                'Chloroquine Injection',
-                                style: TextStyle(
-                                    color: isSelected ? Theme.of(context).primaryColorLight: Theme.of(context).primaryColorDark,
-                                    fontWeight: FontWeight.bold),
-                              ),
-                              SizedBox(height: widget.height * 0.005),
-                              Text(
-                                '1 shots once daily',
-                                style: TextStyle(color: isSelected ? Theme.of(context).primaryColorLight: Theme.of(context).primaryColorDark),
-                              ),
-                            ],
-                          ),
-                        ],
-                      ),
-                      SizedBox(
-                        height: Config.yMargin(context, 1),
-                        width: double.infinity,
-                      ),
-                      Divider(
-                        color: Theme.of(context).primaryColorLight,
-                        height: widget.height * 0.02,
-//indent: 50.0,
-                        endIndent: 10.0,
-                      ),
-                      Visibility(
-                        visible: isSelected,
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          width: widget.width * 0.2,
+                          height: widget.height * 0.1,
+                        ),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: <Widget>[
-                            FlatButton(
-                              onPressed: () {
-                                Navigator.pushNamed(context, RouteNames.drugDescription);
-                              },
-                              child: Text(
-                                'View',
-                                style: TextStyle(
-                                    fontWeight: FontWeight.bold,
-                                    color: isSelected ? Theme.of(context).primaryColorLight: Theme.of(context).primaryColorDark),
-                              ),
+                            Text(
+                              'Chloroquine Injection',
+                              style: TextStyle(
+                                  color: isSelected
+                                      ? Theme.of(context).primaryColorLight
+                                      : Theme.of(context).primaryColorDark,
+                                  fontWeight: FontWeight.bold),
                             ),
-                            FlatButton(
-                              child: Row(
-                                children: <Widget>[
-                                  Icon(
-                                    Icons.close,
-                                    color: isSelected ? Theme.of(context).primaryColorLight: Theme.of(context).primaryColorDark,
-                                    size: Config.textSize(context, 3),
-                                  ),
-                                  SizedBox(
-                                    width: Config.xMargin(context, 2),
-                                  ),
-                                  Text(
-                                    'Skip',
-                                    style: TextStyle(
-                                        fontWeight: FontWeight.bold,
-                                        color: isSelected ? Theme.of(context).primaryColorLight: Theme.of(context).primaryColorDark),
-                                  )
-                                ],
-                              ),
-                              onPressed: () {},
+                            SizedBox(height: widget.height * 0.005),
+                            Text(
+                              '1 shots once daily',
+                              style: TextStyle(
+                                  color: isSelected
+                                      ? Theme.of(context).primaryColorLight
+                                      : Theme.of(context).primaryColorDark),
                             ),
-                            FlatButton(
-                              onPressed: () {},
-                              child: Row(
-                                children: <Widget>[
-                                  Icon(
-                                    Icons.done,
-                                    color: isSelected ? Theme.of(context).primaryColorLight: Theme.of(context).primaryColorDark,
-                                    size: Config.textSize(context, 3),
-                                  ),
-                                  SizedBox(
-                                    width: Config.xMargin(context, 2),
-                                  ),
-                                  Text(
-                                    'Done',
-                                    style: TextStyle(
-                                        fontWeight: FontWeight.bold,
-                                        color: isSelected ? Theme.of(context).primaryColorLight: Theme.of(context).primaryColorDark),
-                                  )
-                                ],
-                              ),
-                            )
                           ],
                         ),
-                      )
-                    ],
-                  )),
-            ]),
-      ),
+                      ],
+                    ),
+                    SizedBox(
+                      height: Config.yMargin(context, 1),
+                      width: double.infinity,
+                    ),
+                    Divider(
+                      color: Theme.of(context).primaryColorLight,
+                      height: widget.height * 0.02,
+//indent: 50.0,
+                      // endIndent: 10.0,
+                    ),
+                    Visibility(
+                      visible: isSelected,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          FlatButton(
+                            onPressed: () {
+                              Navigator.pushNamed(
+                                  context, RouteNames.drugDescription);
+                            },
+                            child: Text(
+                              'View',
+                              style: TextStyle(
+                                  fontWeight: FontWeight.bold,
+                                  color: isSelected
+                                      ? Theme.of(context).primaryColorLight
+                                      : Theme.of(context).primaryColorDark),
+                            ),
+                          ),
+                          FlatButton(
+                            child: Row(
+                              children: <Widget>[
+                                Icon(
+                                  Icons.close,
+                                  color: isSelected
+                                      ? Theme.of(context).primaryColorLight
+                                      : Theme.of(context).primaryColorDark,
+                                  size: Config.textSize(context, 3),
+                                ),
+                                SizedBox(
+                                  width: Config.xMargin(context, 2),
+                                ),
+                                Text(
+                                  'Skip',
+                                  style: TextStyle(
+                                      fontWeight: FontWeight.bold,
+                                      color: isSelected
+                                          ? Theme.of(context).primaryColorLight
+                                          : Theme.of(context).primaryColorDark),
+                                )
+                              ],
+                            ),
+                            onPressed: () {},
+                          ),
+                          FlatButton(
+                            onPressed: () {},
+                            child: Row(
+                              children: <Widget>[
+                                Icon(
+                                  Icons.done,
+                                  color: isSelected
+                                      ? Theme.of(context).primaryColorLight
+                                      : Theme.of(context).primaryColorDark,
+                                  size: Config.textSize(context, 3),
+                                ),
+                                SizedBox(
+                                  width: Config.xMargin(context, 2),
+                                ),
+                                Text(
+                                  'Done',
+                                  style: TextStyle(
+                                      fontWeight: FontWeight.bold,
+                                      color: isSelected
+                                          ? Theme.of(context).primaryColorLight
+                                          : Theme.of(context).primaryColorDark),
+                                )
+                              ],
+                            ),
+                          )
+                        ],
+                      ),
+                    )
+                  ],
+                )),
+          ]),
     );
   }
 }

--- a/lib/ui/widget/progress_card.dart
+++ b/lib/ui/widget/progress_card.dart
@@ -1,0 +1,72 @@
+import 'package:MedBuzz/ui/size_config/config.dart';
+import 'package:flutter/material.dart';
+
+class ProgressCard extends StatelessWidget {
+  final String title;
+  final int progress;
+  final int total;
+  final double width;
+  final double height;
+  final Widget child;
+  final Color progressBarColor;
+  const ProgressCard(
+      {Key key,
+      this.title,
+      this.progress,
+      this.height,
+      this.total,
+      this.width,
+      this.child,
+      this.progressBarColor})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(
+          horizontal: Config.xMargin(context, 3),
+          vertical: Config.yMargin(context, 0.25)),
+      height: Config.yMargin(context, 20),
+      width: width,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(Config.xMargin(context, 5)),
+        boxShadow: [
+          BoxShadow(
+            color: Theme.of(context).primaryColorLight,
+            spreadRadius: Config.xMargin(context, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          child ?? Text(''),
+          SizedBox(
+            height: Config.yMargin(context, 3),
+          ),
+          Stack(
+            children: [
+              Container(
+                height: height,
+                width: width,
+                decoration: BoxDecoration(
+                    color: Color(0xffEEEEEE),
+                    borderRadius:
+                        BorderRadius.circular(Config.xMargin(context, 5))),
+              ),
+              Container(
+                height: height,
+                width: width * (progress / total),
+                decoration: BoxDecoration(
+                    color: progressBarColor,
+                    borderRadius:
+                        BorderRadius.circular(Config.xMargin(context, 5))),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- created progress card widget, it accepts the totalValue, and the attained value, progressBarColor, height of the progress bar and a child component for whatever widget you want on top the progress bar.
- to measure progress, it divides the attainedvalue by the total value to get a percentage
- refactored homepage to use medicationcard, appointmentcard and progresscard widgets, also removed explicitly stated values for fonts and colors and margins and replaced with Config values.