### PR TITLE
Increased Description box height add medication screen

### DIFF
--- a/lib/ui/views/add_medication/add_medication_screen.dart
+++ b/lib/ui/views/add_medication/add_medication_screen.dart
@@ -127,7 +127,8 @@ class _AddMedicationScreenState extends State<AddMedicationScreen> {
                   //Description Text Input
                   SizedBox(height: Config.yMargin(context, 1.5)),
                   TextField(
-                    maxLines: null,
+                    keyboardType: TextInputType.multiline,
+                    maxLines: 5,
                     controller: descriptionTextController,
                     cursorColor: Theme.of(context).primaryColorDark,
                     style: TextStyle(

--- a/local.properties
+++ b/local.properties
@@ -4,5 +4,5 @@
 # Location of the SDK. This is only used by Gradle.
 # For customization when using a Version Control System, please read the
 # header note.
-#Fri Jul 10 00:33:58 WAT 2020
-sdk.dir=C\:\\Users\\Crazelu\\AppData\\Local\\Android\\Sdk
+#Fri Jul 10 17:07:56 WAT 2020
+sdk.dir=/Users/ayshabintmahmud/Library/Android/sdk


### PR DESCRIPTION
Its a description box and should not have a field for something like DrugName. 
<img width="229" alt="Screenshot 2020-07-10 at 5 15 51 PM" src="https://user-images.githubusercontent.com/40881194/87176167-a0cd8b80-c2d1-11ea-842e-0e5f6f012983.png">
<img width="213" alt="Screenshot 2020-07-10 at 5 17 08 PM" src="https://user-images.githubusercontent.com/40881194/87176169-a2974f00-c2d1-11ea-95b0-331c97203159.png">

